### PR TITLE
Rename namespace "cron" -> "old_cron"

### DIFF
--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -4,19 +4,19 @@
   </div>
   <div class='col-sm-7 pull-right' style="margin-top: 20px; margin-bottom: 10px;">
     <% if @cron_jobs.size > 0 %>
-      <form action="<%= root_path %>cron/__all__/delete" method="post" class="pull-right">
+      <form action="<%= root_path %>old_cron/__all__/delete" method="post" class="pull-right">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
         <input class="btn btn-small btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
       </form>
-      <form action="<%= root_path %>cron/__all__/disable" method="post" class="pull-right">
+      <form action="<%= root_path %>old_cron/__all__/disable" method="post" class="pull-right">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
         <input class="btn btn-small" type="submit" name="enque" value="<%= t('DisableAll') %>" />
       </form>
-      <form action="<%= root_path %>cron/__all__/enable" method="post" class="pull-right">
+      <form action="<%= root_path %>old_cron/__all__/enable" method="post" class="pull-right">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
         <input class="btn btn-small" type="submit" name="enque" value="<%= t('EnableAll') %>" />
       </form>
-      <form action="<%= root_path %>cron/__all__/enque" method="post" class="pull-right">
+      <form action="<%= root_path %>old_cron/__all__/enque" method="post" class="pull-right">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
         <input class="btn btn-small" type="submit" name="enque" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
       </form>
@@ -41,7 +41,7 @@
         <tr>
           <td style="<%= style %>"><%= t job.status %></td>
           <td style="<%= style %>">
-            <a href="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>">
+            <a href="<%= root_path %>old_cron/<%= CGI.escape(job.name).gsub('+', '%20') %>">
               <b><%= job.name %></b>
             </a>
             <hr style="margin:3px;border:0;">
@@ -59,24 +59,24 @@
           <td style="<%= style %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
           <td style="<%= style %>">
             <% if job.status == 'enabled' %>
-              <form action="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/enque" method="post">
+              <form action="<%= root_path %>old_cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/enque" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
               </form>
-              <form action="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/disable" method="post">
+              <form action="<%= root_path %>old_cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/disable" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-xs pull-left' type="submit" name="disable" value="<%= t('Disable') %>"/>
               </form>
             <% else %>
-              <form action="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/enque" method="post">
+              <form action="<%= root_path %>old_cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/enque" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>"/>
               </form>
-              <form action="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/enable" method="post">
+              <form action="<%= root_path %>old_cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/enable" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-xs pull-left' type="submit" name="enable" value="<%= t('Enable') %>"/>
               </form>
-              <form action="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/delete" method="post">
+              <form action="<%= root_path %>old_cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/delete" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-xs btn-danger pull-left' type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => job.name) %>"/>
               </form>

--- a/lib/sidekiq/cron/views/cron.slim
+++ b/lib/sidekiq/cron/views/cron.slim
@@ -4,16 +4,16 @@ header.row
 
   .span.col-sm-7.pull-right style="margin-top: 20px; margin-bottom: 10px;"
     - if @cron_jobs.size > 0
-      form.pull-right action="#{root_path}cron/__all__/delete" method="post"
+      form.pull-right action="#{root_path}old_cron/__all__/delete" method="post"
         = csrf_tag if respond_to?(:csrf_tag)
         input.btn.btn-small.pull-left.btn-danger type="submit" name="enque" value="#{t('DeleteAll')}" data-confirm="#{t('AreYouSureDeleteCronJobs')}"
-      form.pull-right action="#{root_path}cron/__all__/disable" method="post"
+      form.pull-right action="#{root_path}old_cron/__all__/disable" method="post"
         = csrf_tag if respond_to?(:csrf_tag)
         input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('DisableAll')}"
-      form.pull-right action="#{root_path}cron/__all__/enable" method="post"
+      form.pull-right action="#{root_path}old_cron/__all__/enable" method="post"
         = csrf_tag if respond_to?(:csrf_tag)
         input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnableAll')}"
-      form.pull-right action="#{root_path}cron/__all__/enque" method="post"
+      form.pull-right action="#{root_path}old_cron/__all__/enque" method="post"
         = csrf_tag if respond_to?(:csrf_tag)
         input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueAll')}" data-confirm="#{t('AreYouSureEnqueueCronJobs')}"
 
@@ -34,7 +34,7 @@ header.row
       tr
         td[style="#{style}"]= job.status
         td[style="#{style}"]
-          a href="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}"
+          a href="#{root_path}old_cron/#{CGI.escape(job.name).gsub('+', '%20')}"
             b = job.name
           hr style="margin:3px;border:0;"
           small
@@ -50,20 +50,20 @@ header.row
         td[style="#{style}"]== job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-"
         td[style="#{style}"]
           -if job.status == 'enabled'
-            form action="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}/enque" method="post"
+            form action="#{root_path}old_cron/#{CGI.escape(job.name).gsub('+', '%20')}/enque" method="post"
               = csrf_tag if respond_to?(:csrf_tag)
               input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueNow')}"
-            form action="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}/disable" method="post"
+            form action="#{root_path}old_cron/#{CGI.escape(job.name).gsub('+', '%20')}/disable" method="post"
               = csrf_tag if respond_to?(:csrf_tag)
               input.btn.btn-small.pull-left type="submit" name="disable" value="#{t('Disable')}"
           -else
-            form action="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}/enque" method="post"
+            form action="#{root_path}old_cron/#{CGI.escape(job.name).gsub('+', '%20')}/enque" method="post"
               = csrf_tag if respond_to?(:csrf_tag)
               input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueNow')}" data-confirm="#{t('AreYouSureEnqueueCronJob', :job => job.name)}"
-            form action="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}/enable" method="post"
+            form action="#{root_path}old_cron/#{CGI.escape(job.name).gsub('+', '%20')}/enable" method="post"
               = csrf_tag if respond_to?(:csrf_tag)
               input.btn.btn-small.pull-left type="submit" name="enable" value="#{t('Enable')}"
-            form action="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}/delete" method="post"
+            form action="#{root_path}old_cron/#{CGI.escape(job.name).gsub('+', '%20')}/delete" method="post"
               = csrf_tag if respond_to?(:csrf_tag)
               input.btn.btn-danger.btn-small type="submit" name="delete" value="#{t('Delete')}" data-confirm="#{t('AreYouSureDeleteCronJob', :job => job.name)}"
 

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -6,7 +6,7 @@
     </h3>
   </div>
   <div class="span col-sm-7 pull-right" style="margin-top: 20px; margin-bottom: 10px;">
-    <% cron_job_path = "#{root_path}cron/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
+    <% cron_job_path = "#{root_path}old_cron/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
     <form action="<%= cron_job_path %>/enque?redirect=<%= cron_job_path %>" class="pull-right" method="post">
       <%= csrf_tag if respond_to?(:csrf_tag) %>
       <input class="btn btn-small pull-left" name="enque" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />

--- a/lib/sidekiq/cron/views/cron_show.slim
+++ b/lib/sidekiq/cron/views/cron_show.slim
@@ -4,7 +4,7 @@ header.row
       = "#{t('Cron')} #{t('Job')}"
       small= @job.name
   .span.col-sm-7.pull-right style=("margin-top: 20px; margin-bottom: 10px;")
-    - cron_job_path = "#{root_path}cron/#{CGI.escape(@job.name).gsub('+', '%20')}"
+    - cron_job_path = "#{root_path}old_cron/#{CGI.escape(@job.name).gsub('+', '%20')}"
     form.pull-right action="#{cron_job_path}/enque?redirect=#{cron_job_path}" method="post"
       = csrf_tag if respond_to?(:csrf_tag)
       input.btn.btn-small.pull-left data-confirm="#{t('AreYouSureEnqueueCronJob', :job => @job.name)}" name="enque" type="submit" value="#{t('EnqueueNow')}"

--- a/lib/sidekiq/cron/web.rb
+++ b/lib/sidekiq/cron/web.rb
@@ -6,8 +6,8 @@ if defined?(Sidekiq::Web)
 
   if Sidekiq::Web.tabs.is_a?(Array)
     # For sidekiq < 2.5
-    Sidekiq::Web.tabs << "cron"
+    Sidekiq::Web.tabs << "old_cron"
   else
-    Sidekiq::Web.tabs["Cron"] = "cron"
+    Sidekiq::Web.tabs["OldCron"] = "old_cron"
   end
 end

--- a/lib/sidekiq/cron/web_extension.rb
+++ b/lib/sidekiq/cron/web_extension.rb
@@ -7,7 +7,7 @@ module Sidekiq
         app.settings.locales << File.join(File.expand_path("..", __FILE__), "locales")
 
         #index page of cron jobs
-        app.get '/cron' do
+        app.get '/old_cron' do
           view_path    = File.join(File.expand_path("..", __FILE__), "views")
 
           @cron_jobs = Sidekiq::Cron::Job.all
@@ -21,7 +21,7 @@ module Sidekiq
         end
 
         # display job detail + jid history
-        app.get '/cron/:name' do
+        app.get '/old_cron/:name' do
           view_path = File.join(File.expand_path("..", __FILE__), "views")
 
           @job = Sidekiq::Cron::Job.find(route_params[:name])
@@ -33,48 +33,48 @@ module Sidekiq
               render(:erb, File.read(File.join(view_path, "cron_show.erb")))
             end
           else
-            redirect "#{root_path}cron"
+            redirect "#{root_path}old_cron"
           end
         end
 
         #enque cron job
-        app.post '/cron/:name/enque' do
+        app.post '/old_cron/:name/enque' do
           if route_params[:name] === '__all__'
             Sidekiq::Cron::Job.all.each(&:enque!)
           elsif job = Sidekiq::Cron::Job.find(route_params[:name])
             job.enque!
           end
-          redirect params['redirect'] || "#{root_path}cron"
+          redirect params['redirect'] || "#{root_path}old_cron"
         end
 
         #delete schedule
-        app.post '/cron/:name/delete' do
+        app.post '/old_cron/:name/delete' do
           if route_params[:name] === '__all__'
             Sidekiq::Cron::Job.all.each(&:destroy)
           elsif job = Sidekiq::Cron::Job.find(route_params[:name])
             job.destroy
           end
-          redirect "#{root_path}cron"
+          redirect "#{root_path}old_cron"
         end
 
         #enable job
-        app.post '/cron/:name/enable' do
+        app.post '/old_cron/:name/enable' do
           if route_params[:name] === '__all__'
             Sidekiq::Cron::Job.all.each(&:enable!)
           elsif job = Sidekiq::Cron::Job.find(route_params[:name])
             job.enable!
           end
-          redirect params['redirect'] || "#{root_path}cron"
+          redirect params['redirect'] || "#{root_path}old_cron"
         end
 
         #disable job
-        app.post '/cron/:name/disable' do
+        app.post '/old_cron/:name/disable' do
           if route_params[:name] === '__all__'
             Sidekiq::Cron::Job.all.each(&:disable!)
           elsif job = Sidekiq::Cron::Job.find(route_params[:name])
             job.disable!
           end
-          redirect params['redirect'] || "#{root_path}cron"
+          redirect params['redirect'] || "#{root_path}old_cron"
         end
 
       end


### PR DESCRIPTION
This allows us to use both `sidekiq-cron` and enterprise periodic jobs in the web UI.